### PR TITLE
Should be GLSL 1.30 into R3DShaderTriangles

### DIFF
--- a/Src/Graphics/New3D/R3DShaderTriangles.h
+++ b/Src/Graphics/New3D/R3DShaderTriangles.h
@@ -3,7 +3,7 @@
 
 static const char *vertexShaderR3D = R"glsl(
 
-#version 120
+#version 130
 
 // uniforms
 uniform float	modelScale;
@@ -61,7 +61,7 @@ void main(void)
 
 static const char *fragmentShaderR3D = R"glsl(
 
-#version 120
+#version 130
 
 uniform sampler2D tex1;			// base tex
 uniform sampler2D tex2;			// micro tex (optional)


### PR DESCRIPTION
These shaders are marked as GLSL 1.20 while they use some GLSL 1.30

See : https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/textureLod.xhtml

This fixes model3emu on my Intel HD Graphics with Linux/Mesa.